### PR TITLE
CASMCMS-7386:  Add the appVersion to the Helm Chart and values.yaml

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -50,6 +50,7 @@ pipeline {
 
                 stage('Chart') {
                     steps {
+                        updateCsmHelmChartAppVersion(chartPath: "${WORKSPACE}/kubernetes/${CHART_NAME}", appVersion:  env.VERSION)
                         sh "make chart"
                     }
                 }


### PR DESCRIPTION
The global.appVersion variable to both the Helm Chart and the
values.yaml file. It will append the value if the variable doesn't exist.
Otherwise, it will update it.

This function was previously done in DST's shared library, and it
was added to CASM's shared library.

(cherry picked from commit 97e23b460a7145f96d2304ef6073b4d35332575a)