### PR TITLE
Pin cray-service chart version to csm-1.0 release range.

### DIFF
--- a/kubernetes/cms-ipxe/requirements.yaml
+++ b/kubernetes/cms-ipxe/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: cray-service
-  version: "^3.0.0"
-  repository: "@cray-algol60"
+  version: "~2.4.0"
+  repository: "@cray-internal"

--- a/kubernetes/cms-ipxe/values.yaml
+++ b/kubernetes/cms-ipxe/values.yaml
@@ -12,7 +12,6 @@ cray-service:
   nameOverride: cray-ipxe
   fullnameOverride: cray-ipxe
   serviceAccountName: cray-ipxe
-  priorityClassName: csm-high-priority-service
   nodeSelector:
     node-discovery.cray.com/networks.node_management: "true"
   replicaCount: 1


### PR DESCRIPTION
This also backs out changes that were mistakenly merged to the 1.0 release branch from CASMCMS-7238.