### PR TITLE
CASMINST-3264: Change to point to artifactory repository

### DIFF
--- a/kubernetes/cms-ipxe/requirements.yaml
+++ b/kubernetes/cms-ipxe/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: cray-service
   version: "^2.0.0"
-  repository: "@cray-internal"
+  repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"


### PR DESCRIPTION
Point at the Artifactory repository, not the Cray internal one. This is
due to our migration to Git Hub, which stores artifacts in a different
artifact repository.