### PR TITLE
CASMCMS-7637: Automatically pull latest patch version of cray-tpsw-clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@
 # themselves need to be dynamically recreated whenever the public CA cert
 # changes.
 
-FROM artifactory.algol60.net/csm-docker/stable/cray-tpsw-ipxe:2.2.7 as base
+FROM artifactory.algol60.net/csm-docker/stable/cray-tpsw-ipxe:@CRAY_TPSW_IPXE_VERSION@ as base
 RUN mkdir /app
 WORKDIR /app
 COPY requirements.txt requirements_test.txt constraints.txt /app/

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ For a local build, you will also need to manually write the .version, .docker_ve
 builds a docker image), and .chart_version (if this repo builds a helm chart) files. When building
 on github, this is done by the setVersionFiles() function.
 
+## Dependency: cray-tpsw-ipxe
+cms-ipxe uses the cray-tpsw-ipxe Docker image built by the ipxe-tpsw-clone reepository.
+We specify the major and minor version of the image we want with the
+[update_external_versions.conf](update_external_versions.conf) file.
+At build time the [runBuildPrep.sh](runBuildPrep.sh) script calls a utility
+which finds the latest version with that major and minor number.
+
+When creating a new release branch, be sure to update this file to specify the
+desired major and minor number of the image for the new release.
+
 ## Versioning
 The version of this repo is generated dynamically at build time by running the version.py script in 
 cms-meta-tools. The version is included near the very beginning of the github build output. 

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,0 +1,84 @@
+# All default values mentioned below are the defaults of the latest_versions tool. If a field
+# is not specified, the update_external_versions tool simply does not pass that argument
+# to the latest_versions tool. So in case of conflicting information, the defaults described
+# in that tool are the ones you should follow.
+
+# This file contains any number of stanzas of the following form:
+#
+#image: image_name
+#    major: major number
+#    minor: minor number
+#    outfile: target filename
+#    server: arti or algol60
+#    source: docker or helm
+#    team: team name
+#    type: build type
+#    url: url of repository.catalog (for docker) or index.yaml (for helm)
+#
+# For each such stanza, the only required field is the image field. This field
+# determines the name of the image whose latest version we wish to discover.
+#
+# The major and minor fields, if present, must contain nonnegative integers.
+# If specified, they constrain the image version search to versions with the
+# specified major and (if specified) minor number. If neither is specified, the
+# overall latest version of the image will be sought.
+#
+# outfile defines the name of the file that the version will be written to.
+# If not specified, it defaults to <image_name>.version
+#
+# server specifies whether the image search should be done on arti.dev or algol60.net
+# If not specified, it defaults to algol60
+#
+# If source is not specified, it defaults to docker.
+# If team is not specified, it defaults to csm.
+#
+# The source, team, and type fields specify where on the server the image search should be done.
+#
+################
+# server: arti #
+################
+#
+# For arti, if type is not specified, it defaults to stable
+#
+# For source docker, the image version will be based on the information found in:
+# https://arti.dev.cray.com/artifactory/<team>-docker-<type>-local/repository.catalog
+#
+# For source helm, the image version will be based on the information found in:
+# https://arti.dev.cray.com/artifactory/<team>-helm-<type>-local/index.yaml
+#
+###################
+# server: algol60 #
+###################
+#
+# For algol60, if type is not specified, it defaults to stable
+#
+# For source docker, the image version will be based on the information found in:
+# https://artifactory.algol60.net/artifactory/<team>-docker/repository.catalog
+#
+# For source helm, the image version will be based on the information found in:
+# https://artifactory.algol60.net/artifactory/<team>-helm-charts/index.yaml
+#
+# For algol60, the type field is used within these files to distinguish between
+# stable and unstable images by looking at the path to the images.
+#
+#######
+# url #
+#######
+#
+# The url field is mutually exclusive with the following fields: server and team
+# It allows you to instead point the tool directly to the file it should retrieve to
+# use as its image index.
+# For source docker, it will assume the file is in the same JSON format as the repository.catalog
+# files found on arti.dev or algol60
+# For source helm, it will assume the file is in the same YAML format as the index.yaml files
+# found on arti.dev or algol60
+# When the url field is used, there is no default type. Thus, if the specified file includes
+# the image type in the file paths (like on algol60), the type must be explicitly specified or
+# no images will be found. Alternatively, if the specified file does NOT include the image type
+# in the file paths (like on arti.dev), the type parameter should be omitted entirely, otherwise
+# no images will be found.
+
+image: cray-tpsw-ipxe
+    major: 2
+    minor: 2
+

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -16,3 +16,7 @@
 #targetfile: 1/2/3.txt
 
 targetfile: kubernetes/cms-ipxe/Chart.yaml
+
+sourcefile: cray-tpsw-ipxe.version
+tag: @CRAY_TPSW_IPXE_VERSION@
+targetfile: Dockerfile


### PR DESCRIPTION
The cray-bss-ipxe image is dependent upon the cray-tpsw-clone Docker
image for its base image. This change allows the build to go out and
automatically find the latest patch version of that Docker image and
pull it in to create the base. This means whenever the cray-tpsw-clone
image changes only a rebuild of this repository is needed to get the
latest image.