### PR TITLE
CASMCMS-7992 Allow for changing ipxe binary names

### DIFF
--- a/kubernetes/cms-ipxe/templates/configmap-settings.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-settings.yaml
@@ -34,3 +34,5 @@ data:
     cray_ipxe_build_shell: {{ .Values.ipxe.build_shell }}
     cray_ipxe_build_with_cert: {{ .Values.ipxe.build_with_cert }}
     cray_ipxe_token_host: {{ .Values.ipxe.api_gw }}
+    cray_ipxe_binary_name: {{ .Values.ipxe.cray_ipxe_binary_name }}
+    cray_ipxe_debug_binary_name: {{ .Values.ipxe.cray_ipxe_debug_binary_name }}

--- a/kubernetes/cms-ipxe/values.yaml
+++ b/kubernetes/cms-ipxe/values.yaml
@@ -144,3 +144,6 @@ ipxe:
   # represents the pathological maximum to boot; in reality nothing should ever get
   # this high.
   bss_ceiling: 64
+
+  cray_ipxe_binary_name: ipxe.efi
+  cray_ipxe_debug_binary_name: debug-ipxe.efi


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Allow sites to change the ipxe and debug-ipxe binary names by setting values within the `cray-ipxe-settings` configmap. Automatically delete the old ipxe binary when the ipxe binary name is changed. This is to prevent cruft and prevent the old binary from being used maliciously. 

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-7992](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7992)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

