### PR TITLE
CASMTRIAGE-3173: Changing the netX boot order

### DIFF
--- a/kubernetes/cms-ipxe/values.yaml
+++ b/kubernetes/cms-ipxe/values.yaml
@@ -117,8 +117,8 @@ ipxe:
   # Overall time incurred on network miss depends on dhcp configuration on the
   # network attached to the NICs, but is about 10 seconds per failed network try.
   nic_boot_order:
-  - net2
   - net0
+  - net2
   - net1
   - net3
   - net4


### PR DESCRIPTION
## Summary and Scope

This is to work around long delays in booting on Surtur. I made this PR on @alexanderkingh 's behalf.

I have concerns about this change because we made net2 first for a specific reason, which I cannot remember.
## Issues and Related PRs

CASMTRIAGE-3173
* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

