### PR TITLE
update internal dev.cray.com addresses to new hpc domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Convert to gitflow/gitversion.
 - CASMCMS-7992 - Allow for changing ipxe binary names.
+- Update internal domain addresses
 
 ## [1.9.4] - (no date)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
+--index-url https://arti.hpc.amslabs.hpecorp.net:443/artifactory/api/pypi/pypi-remote/simple
 
 -c constraints.txt
 

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -41,10 +41,10 @@
 # For arti, if type is not specified, it defaults to stable
 #
 # For source docker, the image version will be based on the information found in:
-# https://arti.dev.cray.com/artifactory/<team>-docker-<type>-local/repository.catalog
+# https://arti.hpc.amslabs.hpecorp.net/artifactory/<team>-docker-<type>-local/repository.catalog
 #
 # For source helm, the image version will be based on the information found in:
-# https://arti.dev.cray.com/artifactory/<team>-helm-<type>-local/index.yaml
+# https://arti.hpc.amslabs.hpecorp.net/artifactory/<team>-helm-<type>-local/index.yaml
 #
 ###################
 # server: algol60 #


### PR DESCRIPTION
## Summary and Scope
Update internal dev.cray.com addresses due to the domain going offline next month.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
As of next month no.
## Issues and Related PRs

* Resolves [issue id](issue link) [CASMCMS-8141](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8141)

## Risks and Mitigations
None know of

## Tests 
Modified deployment on mug environment to include new image.  Initialized the pod with the new image without failure.

## Pull Request Checklist

- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated


