### PR TITLE
CASMCMS-8149: Add cleanup of old debug.efi binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- CASMCMS-8149 - Fixed cleanup of old debug binary leftover from upgrade
+
 
 ## [1.10.0] - 2022-06-22 
 

--- a/src/crayipxe/service.py
+++ b/src/crayipxe/service.py
@@ -516,6 +516,17 @@ def main():
                                                     ipxe_build_debug=ipxe_build_debug,
                                                     ipxe_build_debug_level=cray_ipxe_debug_level)
 
+            # The upgrade to cms-ipxe 1.10.0 changed the default name, potentially leaving an old file
+            # This file still contains a valid token and should be cleaned up if not in use
+            cruft_ipxe_debug_binary = os.path.join(TFTP_MOUNT_DIR, 'debug.efi')
+            if ipxe_debug_binary != cruft_ipxe_debug_binary and new_ipxe_debug_binary != cruft_ipxe_debug_binary:
+                if os.path.exists(cruft_ipxe_debug_binary):
+                    try:
+                        LOGGER.info(f'Removing old ipxe debug binary {cruft_ipxe_debug_binary}')
+                        os.remove(cruft_ipxe_debug_binary)
+                    except IOError:
+                        LOGGER.warning(f'Could not remove old ipxe debug binary {cruft_ipxe_debug_binary}')
+
             if not ipxe_debug_binary == new_ipxe_debug_binary:
                 if ipxe_debug_binary and os.path.exists(ipxe_debug_binary):
                     try:


### PR DESCRIPTION
## Summary and Scope

The upgrade from 1.9.3 to 1.10.0 changed the default name of the debug binary, resulting in the pod not ever cleaning up the old file, which was a problem when enabling the name randomization of binaries for security, as this left an unrandomized and valid binary in place.

## Issues and Related PRs

* Resolves CASMCMS-8149

## Testing

### Tested on:

  * Wasp

### Test description:

- Updated the image and ensured that it cleaned up the old file.  Also ran with no matching file to make sure there wouldn't be problems on future runs after the cleanup.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

