### PR TITLE
Feature/vsha 547

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2023-03-16
+### Fixed
+- Make the build architecture and kind configurable to allow use on platforms that require KPXE binaries.
+
 ### Changed
 - Spelling corrections.
 - Enabled building of unstable artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.12.0] - 2023-03-16
 ### Fixed
 - Make the build architecture and kind configurable to allow use on platforms that require KPXE binaries.
 

--- a/kubernetes/cms-ipxe/templates/configmap-settings.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-settings.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cms-ipxe/templates/configmap-settings.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-settings.yaml
@@ -36,3 +36,5 @@ data:
     cray_ipxe_token_host: {{ .Values.ipxe.api_gw }}
     cray_ipxe_binary_name: {{ .Values.ipxe.cray_ipxe_binary_name }}
     cray_ipxe_debug_binary_name: {{ .Values.ipxe.cray_ipxe_debug_binary_name }}
+    cray_ipxe_build_arch: {{  .Values.ipxe.cray_ipxe_build_arch }}
+    cray_ipxe_build_kind: {{  .Values.ipxe.cray_ipxe_build_kind }}

--- a/kubernetes/cms-ipxe/templates/post-upgrade.yaml
+++ b/kubernetes/cms-ipxe/templates/post-upgrade.yaml
@@ -48,7 +48,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: cms-ipxe-migration
-        image: "artifactory.algol60.net/csm-docker/stable/cray-bss-ipxe:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.post_upgrade.image.repository }}:{{ .Chart.AppVersion }}"
         command:
         - '/bin/sh'
         - '-c'

--- a/kubernetes/cms-ipxe/values.yaml
+++ b/kubernetes/cms-ipxe/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cms-ipxe/values.yaml
+++ b/kubernetes/cms-ipxe/values.yaml
@@ -147,3 +147,12 @@ ipxe:
 
   cray_ipxe_binary_name: ipxe.efi
   cray_ipxe_debug_binary_name: debug-ipxe.efi
+
+  # Allow specification of an architecture other than x86_64 and a kind other than
+  # EFI.  Currently, the only supported architecture is 'x86_64' and the supported
+  # kinds are 'efi' and 'kpxe'.
+  #
+  # If you set the kind to 'kpxe' here, you also want to set the binary name (above)
+  # to 'undionly.kpxe' and the debug binary name to 'debug-undionly.kpxe'.
+  cray_ipxe_build_arch: x86_64
+  cray_ipxe_build_kind: efi

--- a/kubernetes/cms-ipxe/values.yaml
+++ b/kubernetes/cms-ipxe/values.yaml
@@ -156,3 +156,7 @@ ipxe:
   # to 'undionly.kpxe' and the debug binary name to 'debug-undionly.kpxe'.
   cray_ipxe_build_arch: x86_64
   cray_ipxe_build_kind: efi
+
+post_upgrade:
+  image:
+    repository: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-bss-ipxe

--- a/src/crayipxe/service.py
+++ b/src/crayipxe/service.py
@@ -464,6 +464,11 @@ def main():
         # ipxe script setting
         bss_script_raw = api_instance.read_namespaced_config_map('cray-ipxe-bss-ipxe', 'services')
         bss_script_new = bss_script_raw.data['bss.ipxe']
+
+        # ipxe binary type and architecture settings...
+        build_arch = settings.get('cray_ipxe_build_arch', 'x86_64')
+        build_kind = settings.get('cray_ipxe_build_kind', 'efi')
+
         if bss_script_new != bss_script:
             bss_script_changed = True
             bss_script = bss_script_new
@@ -480,7 +485,8 @@ def main():
             new_ipxe_binary = create_binaries(api_instance, ipxe_binary_name, bss_script, cert=public_cert,
                                               bearer_token=bearer_token,
                                               ipxe_build_debug=ipxe_build_debug,
-                                              ipxe_build_debug_level=cray_ipxe_debug_level)
+                                              ipxe_build_debug_level=cray_ipxe_debug_level,
+                                              arch=build_arch, kind=build_kind)
 
             if not ipxe_binary == new_ipxe_binary:
                 if ipxe_binary and os.path.exists(ipxe_binary):
@@ -514,7 +520,8 @@ def main():
                                                     cert=public_cert,
                                                     bearer_token=bearer_token,
                                                     ipxe_build_debug=ipxe_build_debug,
-                                                    ipxe_build_debug_level=cray_ipxe_debug_level)
+                                                    ipxe_build_debug_level=cray_ipxe_debug_level,
+                                                    arch=build_arch, kind=build_kind)
 
             # The upgrade to cms-ipxe 1.10.0 changed the default name, potentially leaving an old file
             # This file still contains a valid token and should be cleaned up if not in use

--- a/src/crayipxe/service.py
+++ b/src/crayipxe/service.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

Add Helm chart content and code to enable the logic for setting the architecture and type when generating the iPXE binary that has been latent in the code for quite a while. This is needed to used cms-ipxe on vShasta because vShasta uses KPXE binaries not EFI.

Backward compatible change.

## Issues and Related PRs

* Resolves [VSHA-547](https://jira-pro.its.hpecorp.net:8443/browse/VSHA-547)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Installed on vShasta v2 system and verified that I could build a KPXE binary using cray-ipxe. Also verified that the chart with no special customizations creates a cray-ipxe that builds an EFI / x86 binary.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

There are no known risks or issues with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

