### PR TITLE
Feature/casmcms 8671

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored liveness code to account for unified source of liveness information
 - Threaded liveness probe heartbeat to detect failed containers
 - Refactored crayipxe/service.py into new multitarchitecture entrant builds into crayipxe/builder.py
+- Update the liveness thread to terminate when the main build thread terminates
 ### Removed
 - Deprecated configuration variables with no viable or used method for configuration
 

--- a/src/crayipxe/builder.py
+++ b/src/crayipxe/builder.py
@@ -469,9 +469,9 @@ class BinaryBuilder(object):
 
                 # Until next time...
                 self.recreation_necessary = False
-            except gaierror as gerror:
+            except gaierror:
                 LOGGER.exception("Generic socket timeout error occurred; retrying at a later point.")
-            except Exception as exception:
+            except Exception:
                 LOGGER.exception("Unhandled exception occurred; retrying at a later point.")
 
 class X86Builder(BinaryBuilder):

--- a/src/crayipxe/liveness/ipxe_timestamp.py
+++ b/src/crayipxe/liveness/ipxe_timestamp.py
@@ -37,6 +37,7 @@ import time
 LOGGER = logging.getLogger(__name__)
 LIVENESS_PATH = '/tmp/ipxe_build_in_progress'
 
+MAIN_THREAD = threading.currentThread()
 
 class BaseipxeTimestampException(BaseException):
     pass
@@ -50,7 +51,6 @@ class ipxeTimestampNoEnt(BaseipxeTimestampException):
 
 
 class ipxeTimestamp(object):
-
     def __init__(self, path, max_age, when=None):
         '''
         Creates a new timestamp representation to <path>; on initialization,
@@ -292,5 +292,8 @@ def liveliness_heartbeat(path):
     """
     timestamp = ipxeTimestamp.byref(path)
     while True:
+        if not MAIN_THREAD.isAlive():
+            # All hope abandon ye who enter here
+            return
         timestamp.refresh()
         time.sleep(10)


### PR DESCRIPTION
## Summary and Scope

This mod enhances the overall behavior of the ipxe builder loop to do the following:
- Log known timeout exceptions that occur as a result of required services not being available
- Blindly try/except and log any other exceptions that happen during normal build in an attempt to keep the main thread always alive.
- Creates a new main thread healthcheck on the heartbeat thread in order to terminate when the main thread has in fact died for whatever reason.

The overall net effect of these changes, is that it is less likely to have a hung pod that is doing nothing as a result of intermittent failures from upstream required services.

## Issues and Related PRs

* Resolves [CASMCMS-8671](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8671)

## Testing

### Tested on:

  * `tyr`

### Test description:

The resultant built image was transferred over to tyr and the affected deployment was modified in place to use the new image. The image was left to run overnight in an attempt to capture an intermittent service failure, however no such event occurred during this window.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

