### PR TITLE
Expose ipxe build kind variable in helm chart values file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Unreleased
+## Unreleased
+### Added
+- Added helm chart passthrough variables for build kind
 
 ## [1.11.4] - 2023-06-29
 ### Added
@@ -16,20 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support to allow two seperate deployments, one for aarch64 and one for x86-64
 - Added aarch64 specific control variables and configmaps for aarch64 builds
 - Added builder log level settings in global configmap
+- Added support for x86 based undionly.kpxe build variant through configmap 'build_kind' variable.
 ### Changed
 - Refactored liveness code to account for unified source of liveness information
 - Threaded liveness probe heartbeat to detect failed containers
 - Refactored crayipxe/service.py into new multitarchitecture entrant builds into crayipxe/builder.py
 - Update the liveness thread to terminate when the main build thread terminates
+- Correct mismatch in aarch64's referenced configmap (previously was still referencing x86's version)
 ### Removed
 - Deprecated configuration variables with no viable or used method for configuration
 
-
-## Unreleased
-### Added
-- Added support for x86 based undionly.kpxe build variant through configmap 'build_kind' variable.
-### Fixed
-- Correct mismatch in aarch64's referenced configmap (previously was still referencing x86's version)
 
 ## [1.11.2] - 2023-04-14
 

--- a/kubernetes/cms-ipxe/templates/configmap-settings.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-settings.yaml
@@ -34,6 +34,7 @@ data:
     cray_ipxe_token_min_remaining_valid_time: {{ .Values.ipxe.token_min_remaining_valid_time }}
     cray_ipxe_build_with_cert: {{ .Values.ipxe.build_with_cert }}
     cray_ipxe_build_service_log_level : {{ .Values.ipxe.build_service_log_level }}
+    cray_ipxe_build_kind: {{ .Values.ipxe.build_kind }}
 
     # x86_64 build options
     cray_ipxe_build_x86: {{ .Values.ipxe.build_x86 }}


### PR DESCRIPTION
## Summary and Scope

A chart variable values file entry was added for affecting build kind. This is used predominantly in vshasta for use with undionly.kpxe variants of builds.

## Issues and Related PRs

* Resolves [CASMCMS-8699](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8699)
* Change will also be needed in `stable/1.5`

## Pull Request Checklist

- [x] Target branch correct
- [x] CHANGELOG.md updated