### PR TITLE
MTL-2371 Optimize NIC loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- MTL-2371 Refactored BSS iPXE network interface loop
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds
 
@@ -14,16 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `tj-actions/changed-files` from 37 to 42 ([#74](https://github.com/Cray-HPE/cms-ipxe/pull/74), [#76](https://github.com/Cray-HPE/cms-ipxe/pull/76), [#79](https://github.com/Cray-HPE/cms-ipxe/pull/79), [#81](https://github.com/Cray-HPE/cms-ipxe/pull/81), [#83](https://github.com/Cray-HPE/cms-ipxe/pull/83))
 - Bump `actions/checkout` from 3 to 4 ([#75](https://github.com/Cray-HPE/cms-ipxe/pull/75))
 - Bump `stefanzweifel/git-auto-commit-action` from 4 to 5 ([#77](https://github.com/Cray-HPE/cms-ipxe/pull/77))
-Bumped depndency patch versions
-| Package                  | From    | To       |
-|--------------------------|---------|----------|
-| `google-auth`            | 1.6.1   | 1.6.3    |
-| `pyasn1`                 | 0.4.4   | 0.4.8    |
-| `pyasn1-modules`         | 0.2.2   | 0.2.8    |
-| `python-dateutil`        | 2.8.1   | 2.8.2    |
-| `rsa`                    | 4.7     | 4.7.2    |
-| `urllib3`                | 1.25.9  | 1.25.11  |
-| `websocket-client`       | 1.5.1   | 1.5.3    |
+- Bumped dependency patch versions:
+  
+    | Package                  | From    | To       |
+    |--------------------------|---------|----------|
+    | `google-auth`            | 1.6.1   | 1.6.3    |
+    | `pyasn1`                 | 0.4.4   | 0.4.8    |
+    | `pyasn1-modules`         | 0.2.2   | 0.2.8    |
+    | `python-dateutil`        | 2.8.1   | 2.8.2    |
+    | `rsa`                    | 4.7     | 4.7.2    |
+    | `urllib3`                | 1.25.9  | 1.25.11  |
+    | `websocket-client`       | 1.5.1   | 1.5.3    |
 
 ## [1.11.6] - 2023-10-26
 ### Changed
@@ -52,7 +54,6 @@ Bumped depndency patch versions
 - Correct mismatch in aarch64's referenced configmap (previously was still referencing x86's version)
 ### Removed
 - Deprecated configuration variables with no viable or used method for configuration
-
 
 ## [1.11.2] - 2023-04-14
 

--- a/kubernetes/cms-ipxe/templates/configmap-bss-aarch64.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-bss-aarch64.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -32,60 +32,67 @@ data:
   bss.ipxe: >
     #!ipxe
 
+    echo Chaining to BSS ...
 
-    echo Chaining to BSS; trying interfaces {{ .Values.ipxe.nic_boot_order | join ", " }}...
-
-
-    set attempt:int32 0
-
-    set maxattempts:int32 {{ .Values.ipxe.bss_max_attempts }}
-
-    set sleepytime:int32 0
-
-    set ceiling:int32 {{ .Values.ipxe.bss_ceiling }}
-
+    set attempt:int16 0
+    set maxattempts:int16 {{ .Values.ipxe.bss_max_attempts }}
+    set sleepytime:int8 0
+    set ceiling:int8 {{ .Values.ipxe.bss_ceiling }}
 
     :start
-
     inc attempt
-
     inc sleepytime
-
     iseq ${sleepytime} ${ceiling} && set sleepytime:int32 {{ 1 | sub .Values.ipxe.bss_ceiling }} ||
-
     iseq ${attempt} ${maxattempts} && goto debug_retry ||
-
-
     echo Chain attempt ${attempt} of ${maxattempts}
+    echo Hint: Press CTRL+C to skip a network interface
+    # Iterate through all of the available network interfaces, starting with nic_index_vip.
+    :dhcpstart
+    set vidx:int8 {{ .Values.ipxe.nic_index_vip }}
+    :dhcpcheck isset ${net${vidx}/mac} || goto retry
 
-    {{- range $netname := .Values.ipxe.nic_boot_order }}
+      #
+      ## Attempt to use the NIC.
+      #
+      ifclose net${vidx} || echo Failed to close net${vidx}
+      sync
+      ifopen net${vidx} || echo Failed to open net${vidx}
+      ifconf -c dhcp net${vidx} && goto configured || ifclose net${vidx}
+    
+      #
+      ## Increment our index and continue.
+      # The VIP index indicates which network interface to try first, before iterating through the
+      # remainder of the interfaces starting with interface zero. For example, a VIP index of 2 
+      # would start with 2 and then proceed through net0, net1, net3, netX before wrapping around
+      # back to net2 once all of the available NICs were exhausted.
 
-    :{{ $netname }}
+      # If our index is 0, increment and continue. Skip all other funny business.
+      iseq ${vidx} 0 && inc vidx && goto dhcpcheck ||
+    
+      # Else, if our current index is 1 less than the starting index, then set the index to 1 after the starting index.
+      iseq ${vidx} {{ sub .Values.ipxe.nic_index_vip 1 }} && set vidx:int8 {{ .Values.ipxe.nic_index_vip | add1 }} && goto dhcpcheck ||
 
-    dhcp {{ $netname }} || goto {{ $netname }}_stop
+      # Else, if our current index is equal to our start index, start over at 0. Otherwise increment by one.
+      iseq ${vidx} {{ .Values.ipxe.nic_index_vip }} && set vidx:int8 0 || inc vidx && goto dhcpcheck
 
-    echo {{ $netname }} IPv4 lease: ${ip} mac: ${ {{- $netname }}/mac}
+      # Else, just plainly increment the index.
+      inc vidx && goto dhcpcheck
 
+    :configured
+    echo net${vidx} IPv4 lease: ${net${vidx}/ip} MAC: ${net${vidx}/mac}
+    chain --timeout {{ $root.Values.ipxe.chain_timeout }} http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${net${vidx}/mac} || echo Failed to retrieve next chain from Boot Script Service over net${vidx} (http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${net${vidx}/mac}) && goto start 
+    ifclose net${vidx} || echo No routes to drop.
 
-    chain --timeout {{ $root.Values.ipxe.chain_timeout }} http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${ {{- $netname }}/mac} || echo Failed to retrieve next chain from Boot Script Service over {{ $netname }} (http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${ {{- $netname }}/mac} && goto {{ $netname }}_stop
-
-    :{{ $netname }}_stop
-
-    ifclose {{ $netname }} || echo No routes to drop.
-
-
-    {{- end }}
-
-
-    echo Failure to chain to BSS over networks associated with NICS: {{ .Values.ipxe.nic_boot_order | join ", " }}; retrying in ${sleepytime} seconds...
-
-    sleep ${sleepytime}
-
+    :retry
+    echo Failed to fetch boot script!
+    echo Retrying in ${sleepytime} seconds ... (CTRL+C to skip)
+    sleep ${sleepytime} ||
     goto start
 
-
     :debug_retry
+    echo IPXE failed to retrieve next chain after ${maxattempts} attempts or was interrupted.
+    goto debug
 
-    echo IPXE failed to retrieve next chain over configured nic networks to a BSS instance after ${maxattempts}.
-
+    :debug
+    echo (type 'exit' to drop into BIOS).
     shell

--- a/kubernetes/cms-ipxe/templates/configmap-bss.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-bss.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -32,60 +32,67 @@ data:
   bss.ipxe: >
     #!ipxe
 
+    echo Chaining to BSS ...
 
-    echo Chaining to BSS; trying interfaces {{ .Values.ipxe.nic_boot_order | join ", " }}...
-
-
-    set attempt:int32 0
-
-    set maxattempts:int32 {{ .Values.ipxe.bss_max_attempts }}
-
-    set sleepytime:int32 0
-
-    set ceiling:int32 {{ .Values.ipxe.bss_ceiling }}
-
+    set attempt:int16 0
+    set maxattempts:int16 {{ .Values.ipxe.bss_max_attempts }}
+    set sleepytime:int8 0
+    set ceiling:int8 {{ .Values.ipxe.bss_ceiling }}
 
     :start
-
     inc attempt
-
     inc sleepytime
-
     iseq ${sleepytime} ${ceiling} && set sleepytime:int32 {{ 1 | sub .Values.ipxe.bss_ceiling }} ||
-
     iseq ${attempt} ${maxattempts} && goto debug_retry ||
-
-
     echo Chain attempt ${attempt} of ${maxattempts}
+    echo Hint: Press CTRL+C to skip a network interface
+    # Iterate through all of the available network interfaces, starting with nic_index_vip.
+    :dhcpstart
+    set vidx:int8 {{ .Values.ipxe.nic_index_vip }}
+    :dhcpcheck isset ${net${vidx}/mac} || goto retry
 
-    {{- range $netname := .Values.ipxe.nic_boot_order }}
+      #
+      ## Attempt to use the NIC.
+      #
+      ifclose net${vidx} || echo Failed to close net${vidx}
+      sync
+      ifopen net${vidx} || echo Failed to open net${vidx}
+      ifconf -c dhcp net${vidx} && goto configured || ifclose net${vidx}
+    
+      #
+      ## Increment our index and continue.
+      # The VIP index indicates which network interface to try first, before iterating through the
+      # remainder of the interfaces starting with interface zero. For example, a VIP index of 2 
+      # would start with 2 and then proceed through net0, net1, net3, netX before wrapping around
+      # back to net2 once all of the available NICs were exhausted.
 
-    :{{ $netname }}
+      # If our index is 0, increment and continue. Skip all other funny business.
+      iseq ${vidx} 0 && inc vidx && goto dhcpcheck ||
+    
+      # Else, if our current index is 1 less than the starting index, then set the index to 1 after the starting index.
+      iseq ${vidx} {{ sub .Values.ipxe.nic_index_vip 1 }} && set vidx:int8 {{ .Values.ipxe.nic_index_vip | add1 }} && goto dhcpcheck ||
 
-    dhcp {{ $netname }} || goto {{ $netname }}_stop
+      # Else, if our current index is equal to our start index, start over at 0. Otherwise increment by one.
+      iseq ${vidx} {{ .Values.ipxe.nic_index_vip }} && set vidx:int8 0 || inc vidx && goto dhcpcheck
 
-    echo {{ $netname }} IPv4 lease: ${ip} mac: ${ {{- $netname }}/mac}
+      # Else, just plainly increment the index.
+      inc vidx && goto dhcpcheck
 
+    :configured
+    echo net${vidx} IPv4 lease: ${net${vidx}/ip} MAC: ${net${vidx}/mac}
+    chain --timeout {{ $root.Values.ipxe.chain_timeout }} http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${net${vidx}/mac} || echo Failed to retrieve next chain from Boot Script Service over net${vidx} (http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${net${vidx}/mac}) && goto start 
+    ifclose net${vidx} || echo No routes to drop.
 
-    chain --timeout {{ $root.Values.ipxe.chain_timeout }} http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${ {{- $netname }}/mac} || echo Failed to retrieve next chain from Boot Script Service over {{ $netname }} (http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${ {{- $netname }}/mac} && goto {{ $netname }}_stop
-
-    :{{ $netname }}_stop
-
-    ifclose {{ $netname }} || echo No routes to drop.
-
-
-    {{- end }}
-
-
-    echo Failure to chain to BSS over networks associated with NICS: {{ .Values.ipxe.nic_boot_order | join ", " }}; retrying in ${sleepytime} seconds...
-
-    sleep ${sleepytime}
-
+    :retry
+    echo Failed to fetch boot script!
+    echo Retrying in ${sleepytime} seconds ... (CTRL+C to skip)
+    sleep ${sleepytime} ||
     goto start
 
-
     :debug_retry
+    echo IPXE failed to retrieve next chain after ${maxattempts} attempts or was interrupted.
+    goto debug
 
-    echo IPXE failed to retrieve next chain over configured nic networks to a BSS instance after ${maxattempts}.
-
+    :debug
+    echo (type 'exit' to drop into BIOS).
     shell

--- a/kubernetes/cms-ipxe/values.yaml
+++ b/kubernetes/cms-ipxe/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -130,21 +130,13 @@ ipxe:
 
   # The following are options that pertain to the resultant interfaces that are
   # allowed as booting devices. By default, the resultant ipxe binary will instruct
-  # nodes to boot over interfaces 2, 0, and 1, in that order. iPXE discovers and
-  # labels interfaces based on how they're discovered based on their PCI id;
-  # as a result, effective networks are attempted one after the other, until a
-  # valid response from the boot script service (BSS) is successful. For systems
-  # with homongenous hardware, it may be possible to alter the order of, or remove
-  # networks which do not correspond to networks which expose boot services.
-  # Overall time incurred on network miss depends on dhcp configuration on the
-  # network attached to the NICs, but is about 10 seconds per failed network try.
-  nic_boot_order:
-  - net2
-  - net0
-  - net1
-  - net3
-  - net4
-  - net5
+  # nodes to boot over interfaces starting with VIP index=2. This VIP index
+  # indicates which network interface to try first, before iterating through the
+  # remainder of the interfaces starting with interface zero. For example,
+  # a VIP index of 2 would start with net2 and then proceed through net0, net1,
+  # net3[, netX].
+  # NOTE: Setting this to a value of 0 disables VIP behavior.
+  nic_index_vip: 2
 
   bss_max_attempts: 1024
 


### PR DESCRIPTION
The hardcoded list of NIC interfaces has two caveats that this change addresses:
1. If a node has more than 5 interfaces, which does happen, then the interfaces beyond the fifth will never be tried.
2. If a node has less than 5 interfaces, the script wastes time trying non-existent interfaces.

To address item 1, we will auto-increment an index until we hit a non-existent NIC.
While doing so, we will maintain the start-index used by cms-ipxe today for compute-node optimization. The loop accounts for this by ensuring that the start index is ran first, and only once.

Item 2 is implicitly addressed by item 1's fix. By only trying NICs that exist, we no longer will attempt using non-existent NICs.

There is also some added logic for trying more consistently, ensuring we close/open the NIC before attempting DHCP.

Lastly this uses smaller `int` sizes, we don't need to allocate 32bit integers for everything.

NOTE: Unfortunately we can't use `iflinkwait` or `--timeout` due to the age of the iPXE source code being used, we could pull those helpful features in if MTL-2104 ever merges
(http://github.com/Cray-HPE/ipxe-tpsw-clone/pull/19).


When the max number of attempts are reached, an `IPXE>` shell will open.
Optionally, a user may interrupt (CTRL+C) the `Retrying in X seconds ...` message to skip to a shell.

```bash
Failed to fetch boot script!
Retrying in 1 seconds ... (CTRL+C to skip)
```

```bash
IPXE failed to retrieve next chain after 1024 attempts or was interrupted.
(type 'exit' to drop into BIOS)
iPXE> exit

 S2600WF
 Intel(R) Xeon(R) Platinum 8160 CPU @ 2.10GHz            @2.10 GHz
 IFWI Version:SE5C620.86B.OR.64.2020.51.2.04.0651.selfboot
 SE5C620.86B.02.01.0013.C0001.121520200651               261120 MB RAM
 Copyright (c) 2006-2020, Intel Corporation

 > Main
 > Advanced
 > Security
 > Server Management
 > Error Manager
 > Boot Manager
 > Boot Maintenance Manager
 > Save & Exit
 > Tls Auth Configuration





                          F10=Save Changes and Exit F9=Reset to Defaults
  ^v=Move Highlight       <Enter>=Select Entry
```

The output also contains hints, telling the user they may skip interfaces using CTRL+C. These hints print out once per attempt.

```
iPXE 1.0.0+ -- Open Source Network Boot Firmware -- http://ipxe.org
Features: DNS HTTP HTTPS iSCSI TFTP SRP AoE EFI Menu
Chaining to BSS ...
Chain attempt 1 of 1024
Hint: Press CTRL+C to skip a network interface
```

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`

### Test description:

- Tested configMap generation
- Tested NCN boots (CN boots not necessary, since the order of NICs tried remained the same)

For the test, I interrupted a few of the attempts in order to emulate a loop failure. In this way, we can observe how only the existing NICs were tired and what happens on success.

```
>>Start PXE over IPv4.
  Station IP address is 10.1.1.8

  Server IP address is 10.92.100.60
  NBP filename is ipxe.efi
  NBP filesize is 1045280 Bytes
 Downloading NBP file...

  NBP file downloaded successfully.
iPXE initialising devices...ok



iPXE 1.0.0+ -- Open Source Network Boot Firmware -- http://ipxe.org
Features: DNS HTTP HTTPS iSCSI TFTP SRP AoE EFI Menu
Chaining to BSS ...
Chain attempt 1 of 1024
Hint: Press CTRL+C to skip a network interface
Waiting for link-up on net2........ ok
Configuring [dhcp] (net2 a4:bf:01:51:15:0a).................. Connection timed out (http://ipxe.org/4c106092)
Waiting for link-up on net0............ Operation canceled (http://ipxe.org/0b072095)
Configuring [dhcp] (net1 a4:bf:01:51:15:09)... Operation canceled (http://ipxe.org/0b072095)
Waiting for link-up on net3... Operation canceled (http://ipxe.org/0b072095)
Waiting for link-up on net4... Operation canceled (http://ipxe.org/0b072095)
Failed to fetch boot script!
Retrying in 1 seconds ... (CTRL+C to skip)
Chain attempt 2 of 1024
Hint: Press CTRL+C to skip a network interface
Configuring [dhcp] (net2 a4:bf:01:51:15:0a).................. Connection timed out (http://ipxe.org/4c106092)
Waiting for link-up on net0................. Down (http://ipxe.org/38086193)
Waiting for link-up on net1........ ok
Configuring [dhcp] (net1 a4:bf:01:51:15:09).......... ok
net1 IPv4 lease: 10.1.1.8 MAC: a4:bf:01:51:15:09
EFITIME is 2024-01-24 20:18:32
https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript...X509 chain 0x5bdb7f68 added X509 0x5bdc3e88 "mug.hpc.amslabs.hpecorp.net"
X509 chain 0x5bdb7f68 added X509 0x5be2e160 "Platform CA - L1 (0d39a12c-3e9e-45e8-81ce-d0f576c59742)"
EFITIME is 2024-01-24 20:18:32
X509 chain 0x5bdb7f68 added X509 0x5be2e2a0 "Platform CA (0d39a12c-3e9e-45e8-81ce-d0f576c59742)"
X509 0x5be2e160 "Platform CA - L1 (0d39a12c-3e9e-45e8-81ce-d0f576c59742)" is a root certificate
X509 0x5bdc3e88 "mug.hpc.amslabs.hpecorp.net" successfully validated using issuer 0x5be2e160 "Platform CA - L1 (0d39a12c-3e9e-45e8-81ce-d0f576c59742)"
 ok
http://rgw-vip.nmn/boot-images/545ba744-d5e4-4725-9960-3bbe2d9be8d0/kernel... ok
http://rgw-vip.nmn/boot-images/545ba744-d5e4-4725-9960-3bbe2d9be8d0/initrd... ok
```
