### PR TITLE
CASMCMS-8914: Use appropriate version of Python k8s client for CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.12.0] - 2024-01-26
+## [1.12.0] - 2024-02-08
 
 ### Changed
 - MTL-2371 Refactored BSS iPXE network interface loop
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `tj-actions/changed-files` from 37 to 42 ([#74](https://github.com/Cray-HPE/cms-ipxe/pull/74), [#76](https://github.com/Cray-HPE/cms-ipxe/pull/76), [#79](https://github.com/Cray-HPE/cms-ipxe/pull/79), [#81](https://github.com/Cray-HPE/cms-ipxe/pull/81), [#83](https://github.com/Cray-HPE/cms-ipxe/pull/83))
 - Bump `actions/checkout` from 3 to 4 ([#75](https://github.com/Cray-HPE/cms-ipxe/pull/75))
 - Bump `stefanzweifel/git-auto-commit-action` from 4 to 5 ([#77](https://github.com/Cray-HPE/cms-ipxe/pull/77))
-- Bumped dependency patch versions:
+- Bump `kubernetes` from 10.0.1 to 22.6.0 to match CSM 1.6 Kubernetes version
+- Bump dependency patch versions:
   
     | Package                  | From    | To       |
     |--------------------------|---------|----------|

--- a/constraints.txt
+++ b/constraints.txt
@@ -3,7 +3,8 @@ certifi==2019.11.28
 chardet==3.0.4
 google-auth==1.6.3
 idna==2.8
-kubernetes==10.0.1
+# CSM 1.6 uses Kubernetes 1.22, so use client v22.x to ensure compatability
+kubernetes==22.6.0
 oauthlib==2.1.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8


### PR DESCRIPTION
I noticed that some of our Python code for CSM 1.6 is pulling in non-optimal versions of the Kubernetes client library. Ideally the major version of the library should correspond to the Kubernetes version on the system, but in many cases it is not. This doesn't guarantee that there will be problems, but it's least risky to use the appropriate version.

This problem also exists in past CSM versions, but this is not the kind of thing worth backporting without additional reason, so I'll just confine my change to CSM 1.6.