### PR TITLE
MTL-2380 Fix carriage returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- MTL-2380 Fix carriage returns when block lives in `>` for BSS iPXE scripts.
+
 ## [1.12.0] - 2024-02-08
 
 ### Changed

--- a/kubernetes/cms-ipxe/templates/configmap-bss-aarch64.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-bss-aarch64.yaml
@@ -62,6 +62,10 @@ data:
 
     set vidx:int8 {{ .Values.ipxe.nic_index_vip }}
 
+    # If the VIP index does not exist, then default to 0. This is useful for systems with less NICs than what the default VIP index is set for.
+
+    isset ${net${vidx}/mac} || set vidx:int8 0
+
     :dhcpcheck isset ${net${vidx}/mac} || goto retry
 
       # Attempt to use the NIC.

--- a/kubernetes/cms-ipxe/templates/configmap-bss-aarch64.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-bss-aarch64.yaml
@@ -35,64 +35,97 @@ data:
     echo Chaining to BSS ...
 
     set attempt:int16 0
+
     set maxattempts:int16 {{ .Values.ipxe.bss_max_attempts }}
+
     set sleepytime:int8 0
+
     set ceiling:int8 {{ .Values.ipxe.bss_ceiling }}
 
     :start
+
     inc attempt
+
     inc sleepytime
+
     iseq ${sleepytime} ${ceiling} && set sleepytime:int32 {{ 1 | sub .Values.ipxe.bss_ceiling }} ||
+
     iseq ${attempt} ${maxattempts} && goto debug_retry ||
+
     echo Chain attempt ${attempt} of ${maxattempts}
+
     echo Hint: Press CTRL+C to skip a network interface
+
     # Iterate through all of the available network interfaces, starting with nic_index_vip.
+
     :dhcpstart
+
     set vidx:int8 {{ .Values.ipxe.nic_index_vip }}
+
     :dhcpcheck isset ${net${vidx}/mac} || goto retry
 
-      #
-      ## Attempt to use the NIC.
-      #
+      # Attempt to use the NIC.
+
       ifclose net${vidx} || echo Failed to close net${vidx}
+
       sync
+
       ifopen net${vidx} || echo Failed to open net${vidx}
+
       ifconf -c dhcp net${vidx} && goto configured || ifclose net${vidx}
     
-      #
-      ## Increment our index and continue.
+      # Increment our index and continue.
+
       # The VIP index indicates which network interface to try first, before iterating through the
+
       # remainder of the interfaces starting with interface zero. For example, a VIP index of 2 
+
       # would start with 2 and then proceed through net0, net1, net3, netX before wrapping around
+
       # back to net2 once all of the available NICs were exhausted.
 
       # If our index is 0, increment and continue. Skip all other funny business.
+
       iseq ${vidx} 0 && inc vidx && goto dhcpcheck ||
     
       # Else, if our current index is 1 less than the starting index, then set the index to 1 after the starting index.
+
       iseq ${vidx} {{ sub .Values.ipxe.nic_index_vip 1 }} && set vidx:int8 {{ .Values.ipxe.nic_index_vip | add1 }} && goto dhcpcheck ||
 
       # Else, if our current index is equal to our start index, start over at 0. Otherwise increment by one.
+
       iseq ${vidx} {{ .Values.ipxe.nic_index_vip }} && set vidx:int8 0 || inc vidx && goto dhcpcheck
 
       # Else, just plainly increment the index.
+
       inc vidx && goto dhcpcheck
 
     :configured
+
     echo net${vidx} IPv4 lease: ${net${vidx}/ip} MAC: ${net${vidx}/mac}
+
     chain --timeout {{ $root.Values.ipxe.chain_timeout }} http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${net${vidx}/mac} || echo Failed to retrieve next chain from Boot Script Service over net${vidx} (http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${net${vidx}/mac}) && goto start 
+
     ifclose net${vidx} || echo No routes to drop.
 
     :retry
+
     echo Failed to fetch boot script!
+
     echo Retrying in ${sleepytime} seconds ... (CTRL+C to skip)
+
     sleep ${sleepytime} ||
+
     goto start
 
     :debug_retry
+
     echo IPXE failed to retrieve next chain after ${maxattempts} attempts or was interrupted.
+
     goto debug
 
     :debug
+
     echo (type 'exit' to drop into BIOS).
+
     shell

--- a/kubernetes/cms-ipxe/templates/configmap-bss.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-bss.yaml
@@ -62,6 +62,10 @@ data:
 
     set vidx:int8 {{ .Values.ipxe.nic_index_vip }}
 
+    # If the VIP index does not exist, then default to 0. This is useful for systems with less NICs than what the default VIP index is set for.
+
+    isset ${net${vidx}/mac} || set vidx:int8 0
+
     :dhcpcheck isset ${net${vidx}/mac} || goto retry
 
       # Attempt to use the NIC.

--- a/kubernetes/cms-ipxe/templates/configmap-bss.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-bss.yaml
@@ -35,64 +35,97 @@ data:
     echo Chaining to BSS ...
 
     set attempt:int16 0
+
     set maxattempts:int16 {{ .Values.ipxe.bss_max_attempts }}
+
     set sleepytime:int8 0
+
     set ceiling:int8 {{ .Values.ipxe.bss_ceiling }}
 
     :start
+
     inc attempt
+
     inc sleepytime
+
     iseq ${sleepytime} ${ceiling} && set sleepytime:int32 {{ 1 | sub .Values.ipxe.bss_ceiling }} ||
+
     iseq ${attempt} ${maxattempts} && goto debug_retry ||
+
     echo Chain attempt ${attempt} of ${maxattempts}
+
     echo Hint: Press CTRL+C to skip a network interface
+
     # Iterate through all of the available network interfaces, starting with nic_index_vip.
+
     :dhcpstart
+
     set vidx:int8 {{ .Values.ipxe.nic_index_vip }}
+
     :dhcpcheck isset ${net${vidx}/mac} || goto retry
 
-      #
-      ## Attempt to use the NIC.
-      #
+      # Attempt to use the NIC.
+
       ifclose net${vidx} || echo Failed to close net${vidx}
+
       sync
+
       ifopen net${vidx} || echo Failed to open net${vidx}
+
       ifconf -c dhcp net${vidx} && goto configured || ifclose net${vidx}
     
-      #
-      ## Increment our index and continue.
+      # Increment our index and continue.
+
       # The VIP index indicates which network interface to try first, before iterating through the
+
       # remainder of the interfaces starting with interface zero. For example, a VIP index of 2 
+
       # would start with 2 and then proceed through net0, net1, net3, netX before wrapping around
+
       # back to net2 once all of the available NICs were exhausted.
 
       # If our index is 0, increment and continue. Skip all other funny business.
+
       iseq ${vidx} 0 && inc vidx && goto dhcpcheck ||
     
       # Else, if our current index is 1 less than the starting index, then set the index to 1 after the starting index.
+
       iseq ${vidx} {{ sub .Values.ipxe.nic_index_vip 1 }} && set vidx:int8 {{ .Values.ipxe.nic_index_vip | add1 }} && goto dhcpcheck ||
 
       # Else, if our current index is equal to our start index, start over at 0. Otherwise increment by one.
+
       iseq ${vidx} {{ .Values.ipxe.nic_index_vip }} && set vidx:int8 0 || inc vidx && goto dhcpcheck
 
       # Else, just plainly increment the index.
+
       inc vidx && goto dhcpcheck
 
     :configured
+
     echo net${vidx} IPv4 lease: ${net${vidx}/ip} MAC: ${net${vidx}/mac}
+
     chain --timeout {{ $root.Values.ipxe.chain_timeout }} http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${net${vidx}/mac} || echo Failed to retrieve next chain from Boot Script Service over net${vidx} (http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${net${vidx}/mac}) && goto start 
+
     ifclose net${vidx} || echo No routes to drop.
 
     :retry
+
     echo Failed to fetch boot script!
+
     echo Retrying in ${sleepytime} seconds ... (CTRL+C to skip)
+
     sleep ${sleepytime} ||
+
     goto start
 
     :debug_retry
+
     echo IPXE failed to retrieve next chain after ${maxattempts} attempts or was interrupted.
+
     goto debug
 
     :debug
+
     echo (type 'exit' to drop into BIOS).
+
     shell


### PR DESCRIPTION
Fix carriage returns to properly handle newlines when a single bracket is used in the YAML.
