### PR TITLE
MTL-2104 Use `hpc` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- MTL-2104 - refresh iPXE codebase.
 
 ## [1.12.1] - 2024-02-29
 

--- a/src/crayipxe/__init__.py
+++ b/src/crayipxe/__init__.py
@@ -28,6 +28,10 @@ import logging
 LOGGER = logging.getLogger(__name__)
 IPXE_BUILD_DIR = '/ipxe'
 
+# Use the HPC iPXE configuration.
+# https://github.com/Cray-HPE/ipxe/tree/master/src/config/hpc
+IPXE_CONFIG = 'hpc'
+
 # Format logs and set the requested log level.
 log_format = "%(asctime)-15s - %(levelname)-7s - %(name)s - %(message)s"
 requested_log_level = os.environ.get('LOG_LEVEL', 'INFO')

--- a/src/crayipxe/__init__.py
+++ b/src/crayipxe/__init__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/crayipxe/builder.py
+++ b/src/crayipxe/builder.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/crayipxe/builder.py
+++ b/src/crayipxe/builder.py
@@ -34,6 +34,7 @@ from urllib.parse import urlparse
 from socket import gaierror
 
 from crayipxe import IPXE_BUILD_DIR
+from crayipxe import IPXE_CONFIG
 from crayipxe.k8s_client import api_instance, client
 from crayipxe.tokens import fetch_token, token_expiring_soon, TOKEN_HOST
 from crayipxe.liveness.ipxe_timestamp import ipxeTimestamp, LIVENESS_PATH, liveliness_heartbeat
@@ -377,6 +378,7 @@ class BinaryBuilder(object):
             build_command.append('CERT=%s' % cert_path_filename)
             build_command.append('TRUST=%s' % cert_path_filename)
         build_command.append('EMBED=%s' % os.path.basename(self.bss_script_path))
+        build_command.append(f'CONFIG={IPXE_CONFIG}')
         s3_host = self.s3_host
         if s3_host:
             build_command.append('S3_HOST=%s' % s3_host)
@@ -404,6 +406,7 @@ class BinaryBuilder(object):
             debug_command.append('CERT=%s' % cert_path_filename)
             debug_command.append('TRUST=%s' % cert_path_filename)
         debug_command.append('EMBED=%s' % os.path.basename(self.debug_script_path))
+        debug_command.append(f'CONFIG={IPXE_CONFIG}')
         s3_host = self.s3_host
         if s3_host:
             debug_command.append('S3_HOST=%s' % s3_host)

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -79,7 +79,7 @@
 # no images will be found.
 
 image: cray-tpsw-ipxe
-    major: 3
+    major: 4
     minor: 0
     outfile: .cray-tpsw-ipxe-version
     server: algol60


### PR DESCRIPTION
Use our fork's "hpc" configuration when compiling iPXE binaries.

Requires this to merge into develop and master: https://github.com/Cray-HPE/ipxe-tpsw-clone/pull/19
