### PR TITLE
CASMINST-6966 DHCP timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /testdeploy.retry
 kubernetes/.packaged/
 **/*__pycache__*
+*.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Makes use of the new `--timeout` parameter for `ifconf -c dhcp` to stretch the window of time iPXE waits for packets to route when an MLAG is in play. This flag is only available after the recent adoption of newer iPXE source from (MTL-2104)[https://jira-pro.it.hpe.com:8443/browse/MTL-2104).
+- Updated `.gitignore` to ignore `Chart.lock` files created when running chart commands locally.
 
 ## [1.13.1] - 2024-07-24
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Makes use of the new `--timeout` parameter for `ifconf -c dhcp` to stretch the window of time iPXE waits for packets to route when an MLAG is in play. This flag is only available after the recent adoption of newer iPXE source from (MTL-2104)[https://jira-pro.it.hpe.com:8443/browse/MTL-2104).
+
 ## [1.13.1] - 2024-07-24
 ### Dependencies
 - Bump `certifi` and `PyJWT` dependency versions to resolve CVEs

--- a/kubernetes/cms-ipxe/templates/configmap-bss-aarch64.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-bss-aarch64.yaml
@@ -59,6 +59,12 @@ data:
     # Iterate through all of the available network interfaces, starting with nic_index_vip.
 
     :dhcpstart
+    
+    # Shut down all interfaces and open them as needed. Sternly prevents iPXE from
+
+    # making bad decisions selecting which interface traffic egresses.
+
+    ifclose
 
     set vidx:int8 {{ .Values.ipxe.nic_index_vip }}
 
@@ -76,7 +82,7 @@ data:
 
       ifopen net${vidx} || echo Failed to open net${vidx}
 
-      ifconf -c dhcp net${vidx} && goto configured || ifclose net${vidx}
+      ifconf -c dhcp --timeout {{ .Values.ipxe.dhcp_timeout }} net${vidx} && goto configured || ifclose net${vidx}
     
       # Increment our index and continue.
 

--- a/kubernetes/cms-ipxe/templates/configmap-bss.yaml
+++ b/kubernetes/cms-ipxe/templates/configmap-bss.yaml
@@ -59,6 +59,12 @@ data:
     # Iterate through all of the available network interfaces, starting with nic_index_vip.
 
     :dhcpstart
+    
+    # Shut down all interfaces and open them as needed. Sternly prevents iPXE from
+
+    # making bad decisions selecting which interface traffic egresses.
+
+    ifclose
 
     set vidx:int8 {{ .Values.ipxe.nic_index_vip }}
 
@@ -76,7 +82,7 @@ data:
 
       ifopen net${vidx} || echo Failed to open net${vidx}
 
-      ifconf -c dhcp net${vidx} && goto configured || ifclose net${vidx}
+      ifconf -c dhcp --timeout {{ .Values.ipxe.dhcp_timeout }} net${vidx} && goto configured || ifclose net${vidx}
     
       # Increment our index and continue.
 

--- a/kubernetes/cms-ipxe/values.yaml
+++ b/kubernetes/cms-ipxe/values.yaml
@@ -123,10 +123,13 @@ ipxe:
   # If a token is going to expire within this number of seconds, update it.
   token_min_remaining_valid_time: 1800
 
+
   # The following are options that pertain to the build environment; checking in
   # values here change the resultant number of build environments that are created
   # as a response to updates or changes in the environment.
   chain_timeout: 10000
+
+  dhcp_timeout: 20000
 
   # The following are options that pertain to the resultant interfaces that are
   # allowed as booting devices. By default, the resultant ipxe binary will instruct


### PR DESCRIPTION
Now that https://github.com/Cray-HPE/ipxe-tpsw-clone/pull/19 has merged into production we have some newer iPXE features at our disposal.

This PR makes use of the new `--timeout` parameter on `ifconf`, extending how long we wait for DHCP to work _after_ a link has opened. This has proven helpful for troublesome systems like mug's 10GBase-T onboard Intel NICs.