### PR TITLE
Add global passthrough build time options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added passthrough option for affecting global build options through the associated configset (global_additional_build_options).
 
 ## [1.14.2] - 2024-09-05
 

--- a/kubernetes/cms-ipxe/values.yaml
+++ b/kubernetes/cms-ipxe/values.yaml
@@ -167,6 +167,13 @@ ipxe:
   # support kpxe/undionly variants.
   build_kind: ipxe
 
+  # This allows injection of new custom build options for ipxe. This is a GLOBAL SETTING, so every build will have these
+  # values included at build time. The format of this value is a comma delimited string. By default, this string is
+  # empty. Changing this value to anything that is not supported by the ipxe build makefile will likely break ALL
+  # builds. Only change this value if you have a solid understanding of the internals of the ipxe build chain, as the
+  # contents of this setting are passed in to the build process as is.
+  global_additional_build_options: ""
+
   # These options are specific to x86_64 ipxe builds
   build_x86: true
   cray_ipxe_binary_name: ipxe.efi

--- a/src/crayipxe/builder.py
+++ b/src/crayipxe/builder.py
@@ -136,6 +136,15 @@ class BinaryBuilder(object):
         return self._global_settings
 
     @property
+    def global_additional_build_options(self):
+        """
+        A list of strings that correspond to MAKE targets for building. These are typically user supplied values that
+        affect the overall build of all ipxe flavors.
+        :return: A list of build options to append at build time.
+        """
+        return self.global_settings.get('global_additional_build_options', '').split(',')
+
+    @property
     def build_kind(self):
         """
         A string value representing the overall kind of artifact this builder produces. Most typically, this is 'ipxe',
@@ -385,6 +394,8 @@ class BinaryBuilder(object):
         build_command.append('BEARER_TOKEN=%s' % self.bearer_token)
         LOGGER.debug("Build command generated as: [%s]" % ' '.join(build_command[:-1]))
         LOGGER.debug("BEARER_TOKEN=<omitted> for reasons of security.")
+        if self.global_additional_build_options:
+            build_command.extend(self.global_additional_build_options)
         return build_command
 
     @property


### PR DESCRIPTION
## Summary and Scope

Per customer request, users want to be able to influence the overall build options for all builds by appending their own ipxe make file options. A new field now exists in the associated ipxe build flags to allow them to easily do this. This is considered an advanced option!

## Issues and Related PRs

* Resolves [CASMCMS-9068](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9068)

## Testing

### Tested on:

  * `mug`
  * Local development environment

## Risks and Mitigations

This allows an unprecedented number of options to be injected during ipxe build time. We do not sanitize the information coming in here because we cannot preclude all of the ways in which users will want to use the feature. With that said, use of this option for power users should result in a way to allow power users to do what they want, and lesser users to shoot themselves in the foot.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

