### PR TITLE
CASMTRIAGE-7409

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] - 2025-05-27
+### Updated
+- updated cray-ipxe-tpsw version to v4.2.0
+
+
 ## [1.15.2] - 2025-1-10
 ### Fixed
 - Assigning unique name to cms-ipxe job to avoid following upgrade issue:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,21 +29,37 @@
 # for downloading ipxe binaries from a secure location. The ipxe binaries
 # themselves need to be dynamically recreated whenever the public CA cert
 # changes.
+
 ARG Upstream=artifactory.algol60.net
 ARG IpxeTag=@CRAY-TPSW-IPXE-VERSION@
 ARG Stable=stable
 FROM $Upstream/csm-docker/$Stable/cray-tpsw-ipxe:$IpxeTag as base
+
 RUN mkdir /app
 WORKDIR /app
+
 COPY requirements.txt requirements_test.txt constraints.txt /app/
-RUN apt -y update && \
-    apt -y install \
-      python3-dev \
-      python3-pip openssl coreutils && \
-    python3 -m pip install --upgrade pip && \
-    python3 -m pip install --no-cache-dir -r /app/requirements.txt
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl git make build-essential libssl-dev zlib1g-dev \
+    libbz2-dev libreadline-dev libsqlite3-dev wget llvm \
+    libncurses5-dev libncursesw5-dev xz-utils tk-dev \
+    libffi-dev liblzma-dev python3-openssl coreutils ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PYENV_ROOT="/opt/pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+
+RUN curl https://pyenv.run | bash && \
+    /opt/pyenv/bin/pyenv install 3.8.10 && \
+    /opt/pyenv/bin/pyenv global 3.8.10 && \
+    ln -sf /opt/pyenv/versions/3.8.10/bin/python3 /usr/local/bin/python3 && \
+    python3 -m ensurepip && python3 -m pip install --upgrade pip
+
+RUN chmod -R a+rX /opt/pyenv
+RUN python3 -m pip install --no-cache-dir -r /app/requirements.txt
 RUN echo 'alias ll="ls -l"' > ~/.bashrc
 RUN chown 65534:65534 -R /ipxe
-COPY /src/crayipxe /app/crayipxe
-ENTRYPOINT python3 -m crayipxe.builds.x86-64
+COPY src/crayipxe /app/crayipxe
+ENTRYPOINT ["python3", "-m", "crayipxe.builds.x86-64"]
 USER 65534:65534

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,18 +1,17 @@
-cachetools==3.0.0
-certifi==2023.7.22
-chardet==3.0.4
-google-auth==1.6.3
-idna==2.8
-# CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatability
-kubernetes>=24.2,<24.3
-oauthlib==2.1.0
-pyasn1==0.4.8
-pyasn1-modules==0.2.8
-PyJWT==2.4.0
-python-dateutil==2.8.2
-PyYAML==5.4.1
-requests==2.23.0
-requests-oauthlib==1.0.0
-rsa==4.7.2
-urllib3==1.25.11
-websocket-client==0.54.0
+cachetools==5.5.2
+certifi==2025.4.26
+google-auth==2.40.2
+idna==3.10
+# CSM 1.7 moved to Kubernetes 1.32. Use client v32.x to ensure compatability
+kubernetes==32.0.1
+oauthlib==3.2.2
+pyasn1==0.6.1
+pyasn1_modules==0.4.2
+PyJWT==2.10.1
+python-dateutil==2.9.0.post0
+PyYAML==6.0.2
+requests==2.32.3
+requests-oauthlib==2.0.0
+rsa==4.9.1
+urllib3==2.4.0
+websocket-client==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@
 kubernetes
 PyJWT
 PyYAML
-urllib3>=1.21.1
+urllib3>=2.4.0

--- a/src/crayipxe/liveness/ipxe_timestamp.py
+++ b/src/crayipxe/liveness/ipxe_timestamp.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,7 +37,7 @@ import time
 LOGGER = logging.getLogger(__name__)
 LIVENESS_PATH = '/tmp/ipxe_build_in_progress'
 
-MAIN_THREAD = threading.currentThread()
+MAIN_THREAD = threading.current_thread()
 
 class BaseipxeTimestampException(BaseException):
     pass
@@ -292,7 +292,7 @@ def liveliness_heartbeat(path):
     """
     timestamp = ipxeTimestamp.byref(path)
     while True:
-        if not MAIN_THREAD.isAlive():
+        if not MAIN_THREAD.is_alive():
             # All hope abandon ye who enter here
             return
         timestamp.refresh()

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,7 +80,7 @@
 
 image: cray-tpsw-ipxe
     major: 4
-    minor: 1
+    minor: 2
     outfile: .cray-tpsw-ipxe-version
     server: algol60
     source: docker


### PR DESCRIPTION
## Summary and Scope

Update IPXE code to fix kernel panic on boot.
https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7409

## Issues and Related PRs

Updated ipxe-tpsw version
https://github.com/Cray-HPE/ipxe-tpsw-clone/pull/41

## Background on the Ubuntu and Python changes
Building the new IPXE code in ipxe-tpsw-clone required a newer version of gcc, which required a newer Ubuntu container image, which ships with python3.12. As a result the python dependencies had to be updated.

## Testing

### Tested on:

- tyr

### Test description:

booted four nodes (x86_64 NCN's, x86_64 and aarch64 compute nodes) numerous times.
This update has also been running for 1 week+ and no issues have been reported.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated