### PR TITLE
CASMCMS-9454 - add pod security context for ceph upgrade.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.1] - 2025-06-06
+### Fixed
+- CASMCMS-9454 - add pod level security context so PVC's are mounted with the correct owner.
+
+### Dependencies
+- Bumped cray-services base chart minimum version to 12.0.0
+
 ## [1.16.0] - 2025-05-27
 ### Dependencies
 - Bump `dangoslen/dependabot-changelog-helper` from 3 to 4 ([#117](https://github.com/Cray-HPE/cms-ipxe/pull/117))

--- a/kubernetes/cms-ipxe/Chart.yaml
+++ b/kubernetes/cms-ipxe/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,7 +30,7 @@ sources:
 - https://github.com/Cray-HPE/cms-ipxe
 dependencies:
 - name: cray-service
-  version: "~11.0"
+  version: "~12.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/images: |

--- a/kubernetes/cms-ipxe/values.yaml
+++ b/kubernetes/cms-ipxe/values.yaml
@@ -45,6 +45,10 @@ deploymentDefaults:
 
 builderDefaults:
   serviceAccountName: cray-ipxe
+  securityContext:
+    runAsUser: 65534
+    runAsGroup: 65534
+    fsGroup: 65534
   containers:
     builder:
       name: cray-ipxe


### PR DESCRIPTION
## Summary and Scope

Due to an upgrade of ceph, if the pod security context isn't set, the pvc mounted volumes will be created with an incorrect ownership and permissions so the 'nobody' user is not able to write to the volume.

## Issues and Related PRs
* Resolves [CASMCMS-9454](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9454)

## Testing
### Tested on:
  * Virtual Shasta

### Test description:

Mikhail manually changed the helm chart and verified this resolves the issue.

## Risks and Mitigations

Low risk - same fix as has been applied to several other services.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

